### PR TITLE
Add in comment when something gets deployed

### DIFF
--- a/deploy_comment.py
+++ b/deploy_comment.py
@@ -1,0 +1,134 @@
+import datetime
+import logging
+import os
+import sys
+
+from utils import notify_irc, parse_link_headers
+
+import requests
+
+log = logging.getLogger()
+handler = logging.StreamHandler(sys.stderr)
+log.addHandler(handler)
+log.setLevel(logging.DEBUG)
+
+logging.getLogger("requests").propagate = False
+
+GITHUB_USERNAME = os.getenv('GITHUB_USERNAME')
+GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+
+log.info('Running deploy_comment.py: {}'.format(datetime.datetime.now()))
+repos = 'https://api.github.com/repos/'
+myself = 'addons-robot'
+
+message = ('This has been deployed to our '
+'[development server](https://addons-dev.allizom.org). Please see '
+'[push duty](https://addons.readthedocs.io/en/latest/server/push-duty.html) '
+'for when it will be deployed to production.')
+
+
+class AlreadyCommented(Exception):
+    pass
+
+
+def has_commented(url):
+    log.debug(url)
+    res = requests.get(url, auth=(GITHUB_USERNAME, GITHUB_TOKEN))
+    res.raise_for_status()
+    for comment in res.json():
+        if myself in comment['user']['login']:
+            raise AlreadyCommented()
+
+    next_url = parse_link_headers(res.headers.get('link', '')).get('next')
+    if next_url:
+        has_commented(next_url)
+
+
+def list_pull_requests(location):
+    # https://developer.github.com/v3/pulls/
+    url = repos + '{}/pulls'.format(location)
+    url = url + '?state=closed'
+
+    res = requests.get(url, auth=(GITHUB_USERNAME, GITHUB_TOKEN))
+    res.raise_for_status()
+    pull_requests = []
+    for pull_request in res.json():
+        if pull_request['number'] < 3179:
+            # Don't comment on old pull requests.
+            continue
+
+        # Note we aren't going to try and paginate through the list, we'll
+        # assume that the last 20 pull requests will usually suffice.
+        try:
+            has_commented(pull_request['_links']['comments']['href'])
+        except AlreadyCommented:
+            log.info('Already commented, ignoring.')
+            continue
+
+        pull_requests.append(pull_request)
+
+    return pull_requests
+
+
+def check_deployed(pull, commit_hash, commits_since):
+    commit = pull['merge_commit_sha']
+    if not commit:
+        return False
+
+    # Would commit_hash == commit ever happen?
+    if (commit_hash in commits_since) or (commit_hash == commit) :
+        # Its been deployed, rejoice.
+        return True
+
+    return False
+
+
+def get_commits(location, endpoint):
+    log.debug(endpoint)
+    res = requests.get(endpoint)
+    res.raise_for_status()
+    commit_hash = res.json()['version']
+
+    url = repos + '{}/commits?sha={}&per_page=100'.format(location, commit_hash)
+    log.debug(url)
+    res = requests.get(url, auth=(GITHUB_USERNAME, GITHUB_TOKEN))
+    res.raise_for_status()
+
+    commits_since = set([commit['sha'] for commit in res.json()])
+    return commit_hash, commits_since
+
+
+def comment_on_pull_request(location, pull):
+    # https://developer.github.com/v3/issues/comments/#create-a-comment
+    url = repos + '{}/issues/{}/comments'.format(location, pull['number'])
+    log.debug(url)
+    res = requests.post(
+        url,
+        json={'body': message},
+        auth=(GITHUB_USERNAME, GITHUB_TOKEN)
+    )
+    res.raise_for_status()
+
+
+if __name__ == '__main__':
+    location = sys.argv[1]
+    assert '/' in location
+    endpoint = sys.argv[2]
+    assert endpoint.startswith('https://')
+
+    notify_irc('Checking for pull requests closed in {}'.format(location))
+    log.info('Checking: {}'.format(location))
+
+    pulls = list_pull_requests(location)
+    log.info('Found: {} pull requests'.format(len(pulls)))
+    commit_hash, commits_since = get_commits(location, endpoint)
+    log.info('Found version on server and last 100 commits.')
+
+    for pull in pulls:
+        if check_deployed(pull, commit_hash, commits_since):
+            comment_on_pull_request(location, pull)
+            log.info('Commented pull request: {}'.format(pull['number']))
+        else:
+            log.info('Pull request not deployed: {}'.format(pull['number']))
+
+    notify_irc('Checking for pull requests completed.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+irc

--- a/triage_label.py
+++ b/triage_label.py
@@ -1,11 +1,10 @@
 import datetime
 import logging
 import os
-import re
 import requests
 import sys
 
-from utils import notify_irc
+from utils import notify_irc, parse_link_headers
 
 log = logging.getLogger()
 handler = logging.StreamHandler(sys.stderr)
@@ -38,10 +37,6 @@ developers = [
 
 
 issues = []
-
-def parse_link_headers(header):
-    rx = '\<(.*?)>; rel="(\w+)"(?:,)'
-    return dict([(v, k) for k, v in re.findall(rx, header)])
 
 
 def list_issues(location):

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+import re
+
 import irc.bot
 
 channel = '#amo-bots'
@@ -27,6 +29,11 @@ def notify_irc(*msgs):
         bot.start()
     except SystemExit:
         print 'exiting'
+
+
+def parse_link_headers(header):
+    rx = '\<(.*?)>; rel="(\w+)"(?:,)'
+    return dict([(v, k) for k, v in re.findall(rx, header)])
 
 
 if __name__=='__main__':


### PR DESCRIPTION
Not sure the message is too helpful yet, and i realised our push duty page isn't that helpful either.

It assumes that if its commented already, we don't comment again.

Assumes that the pull request would be somewhere in the last 100 merges, which seems reasonable.